### PR TITLE
Fix indexer chip geometry

### DIFF
--- a/stacchip/indexer.py
+++ b/stacchip/indexer.py
@@ -97,8 +97,14 @@ class ChipIndexer:
             for asset in self.item.assets.values():
                 if key not in asset.extra_fields:
                     continue
-                if not data or data[0] < asset.extra_fields[key][0]:
-                    data = asset.extra_fields[key]
+                # Get largest shape or smallest transform (scaling).
+                if 'shape' in key:
+                    if not data or data[0] < asset.extra_fields[key][0]:
+                        data = asset.extra_fields[key]
+                else:
+                    if not data or data[0] > asset.extra_fields[key][0]:
+                        data = asset.extra_fields[key]
+
         if not data:
             raise ValueError("Could not determine {key} for this STAC item")
 

--- a/stacchip/indexer.py
+++ b/stacchip/indexer.py
@@ -100,7 +100,7 @@ class ChipIndexer:
                 if key not in asset.extra_fields:
                     continue
                 # Get largest shape or smallest transform (scaling).
-                if 'shape' in key:
+                if "shape" in key:
                     if not data or data[0] < asset.extra_fields[key][0]:
                         data = asset.extra_fields[key]
                 else:

--- a/stacchip/indexer.py
+++ b/stacchip/indexer.py
@@ -68,6 +68,8 @@ class ChipIndexer:
             return CRS.from_epsg(self.item.properties["proj:epsg"])
         elif "proj:wkt2" in self.item.properties:
             return CRS.from_string(self.item.properties["proj:wkt2"])
+        elif "proj:code" in self.item.properties:
+            return CRS.from_string(self.item.properties["proj:code"])
         else:
             raise ValueError("Could not identify CRS of source files")
 


### PR DESCRIPTION
_get_trsf_or_shape method was finding highest resolution for shape and lowest for transform (largest x_scaling value). Consequently, chip boundary boxes were being blown up. Fix now finds value corresponding to highest resolution for both shape and transform.

pystac.Item.from_file() now changes proj:epsg attribute to proj:code. Added an elif clause to account for this change.